### PR TITLE
Atualiza licença e adiciona URL do Packagist ao composer.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,21 @@
-CNPJUtils License
+Licença MIT
+===========
 
-This project is licensed under a dual license:
+Copyright (c) 2024 Samuel Pietro / CNPJUtils
 
-1. **Non-Commercial Use**:
-   - You are free to use, modify, and distribute this software for non-commercial purposes.
-   - Attribution to the original author, Samuel Pietro, is required.
+A permissão é concedida, gratuitamente, a qualquer pessoa que obtenha uma cópia deste software e dos arquivos de
+documentação associados (o "Software"), para lidar com o Software sem restrição, incluindo, sem limitação, os direitos
+de usar, copiar, modificar, mesclar, publicar, distribuir, sublicenciar e/ou vender cópias do Software, e permitir que
+as pessoas a quem o Software é fornecido o façam, sujeitas às seguintes condições:
 
-2. **Commercial Use**:
-   - You are permitted to use, modify, and distribute this software for commercial purposes.
-   - Attribution to the original author, Samuel Pietro, is required.
-   - The original credit must be maintained even after modifications.
+A condição acima é que o aviso de direitos autorais e esta permissão sejam incluídos em todas as cópias ou partes
+substanciais do Software.
 
-**© 2024 Samuel Pietro / CNPJUtils**
+Além disso, a atribuição ao autor original, Samuel Pietro, deve ser mantida em todas as cópias, modificações ou
+distribuições do Software.
+
+O SOFTWARE É FORNECIDO "COMO ESTÁ", SEM GARANTIA DE QUALQUER TIPO, EXPRESSA OU IMPLÍCITA, INCLUINDO, MAS NÃO SE
+LIMITANDO ÀS GARANTIAS DE COMERCIABILIDADE, ADEQUAÇÃO A UM DETERMINADO FIM E NÃO VIOLAÇÃO. EM NENHUM CASO OS AUTORES
+OU DETENTORES DOS DIREITOS AUTORAIS SERÃO RESPONSÁVEIS POR QUALQUER REIVINDICAÇÃO, DANOS OU OUTRA RESPONSABILIDADE,
+SEJA EM UMA AÇÃO DE CONTRATO, DELITO OU DE OUTRA FORMA, DECORRENTE DE, FORA DE OU EM CONEXÃO COM O SOFTWARE OU O USO OU
+OUTRAS NEGOCIAÇÕES NO SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Funções úteis para gerar e validar números de CNPJ no novo padrão alfanumérico.",
   "type": "library",
   "license": "proprietary",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "autoload": {
     "psr-4": {
       "CNPJUtils\\": "src/"
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/SamuelPietro/cnpjutils",
   "support": {
     "issues": "https://github.com/SamuelPietro/cnpjutils/issues",
-    "source": "https://github.com/SamuelPietro/cnpjutils"
+    "source": "https://github.com/SamuelPietro/cnpjutils",
+    "packagist": "https://packagist.org/packages/samuelpietro/cnpjutils"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # CNPJUtils
 ![PHP](https://img.shields.io/badge/PHP-%3E%3D%207.4-blue)
-![License](https://img.shields.io/badge/license-NonCommercial-blue)
+![License](https://img.shields.io/badge/license-mit-blue)
 
 **CNPJUtils** é uma biblioteca PHP de código aberto que oferece funções úteis para trabalhar com o novo padrão de CNPJ
 alfanumérico do Brasil. Esta biblioteca permite calcular dígitos verificadores e validar o formato do CNPJ conforme o
@@ -171,10 +171,9 @@ Para enviar pull requests siga os passos abaixo.
 
 ## Licença
 
-Este projeto está licenciado sob uma licença de uso não comercial livre e uso comercial com atribuição:
-
-- **Uso não comercial**: Modificação, cópia e redistribuição são permitidas para fins não comerciais.
-- **Uso comercial**: Permitido com atribuição ao autor original, mantendo o crédito original mesmo após modificações.
+Este projeto está licenciado sob a Licença MIT, que permite o uso, modificação e distribuição do software para qualquer
+finalidade, desde que a atribuição ao autor original, Samuel Pietro, seja mantida em todas as cópias, modificações ou
+distribuições do Software.
 
 **© 2024 Samuel Pietro / CNPJUtils**
 


### PR DESCRIPTION
Este pull request inclui as seguintes mudanças:

- Atualiza a licença para MIT com atribuição obrigatória ao autor original.
- Adiciona a URL do Packagist ao campo `support` no arquivo `composer.json`.

Essas mudanças garantem que a licença do projeto esteja clara e que o pacote seja facilmente encontrado no Packagist.